### PR TITLE
feat: implement eventbase manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 data
+test-data
 lib

--- a/README.md
+++ b/README.md
@@ -1,39 +1,66 @@
 # Eventbase
-A distributed event-sourced database built on NATS JetStream.
+
+A distributed, event-sourced, key-value database built on top of **NATS JetStream**. Eventbase provides a simple yet powerful API for storing, retrieving, and subscribing to data changes, with automatic state synchronization across distributed instances.
 
 ## Features
-- Event sourcing with automatic metadata tracking
-- Distributed state synchronization across instances
-- Real-time data subscriptions with pattern matching
-- Simple key-value storage API
-- Automatic metadata tracking (creation date, modification date, change count)
-- Support for large datasets
-- Pattern-based key filtering
-- Special character support in keys
+
+- **Event Sourcing**: All changes are captured as events, enabling a complete history of data modifications.
+- **Distributed Synchronization**: Instances automatically synchronize state via NATS JetStream.
+- **Real-time Subscriptions**: Subscribe to data changes with pattern matching support.
+- **Metadata Tracking**: Automatic tracking of creation date, modification date, and change count for each key.
+- **Persistent Storage**: Supports persistent storage with configurable data paths.
+- **Pattern-based Key Filtering**: Retrieve keys based on patterns using regex.
+- **Special Character Support**: Keys can contain special characters; they are base64-encoded when used in NATS subjects.
+- **Multi-instance Management**: Efficiently manage multiple Eventbase instances with automatic cleanup of inactive streams.
+- **Resilience**: Automatically resumes from stored data after restarts or failures.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Usage](#usage)
+  - [Storing Data](#storing-data)
+  - [Retrieving Data](#retrieving-data)
+  - [Deleting Data](#deleting-data)
+  - [Listing Keys](#listing-keys)
+  - [Subscribing to Changes](#subscribing-to-changes)
+  - [Closing the Connection](#closing-the-connection)
+- [Eventbase Manager](#eventbase-manager)
+- [API](#api)
+  - [Eventbase](#eventbase)
+  - [EventbaseManager](#eventbasemanager)
+- [Examples](#examples)
+  - [Advanced Subscription](#advanced-subscription)
+  - [Using with Multiple Streams](#using-with-multiple-streams)
+- [Development](#development)
 
 ## Installation
+
 ```bash
 npm install @markwylde/eventbase
 ```
 
 ## Prerequisites
-- NATS Server with JetStream enabled
-- Node.js 20 or higher
+
+- **NATS Server** with JetStream enabled.
+- **Node.js 20** or higher.
 
 ## Quick Start
+
 ```javascript
 import createEventbase from '@markwylde/eventbase';
 
-// Initialize eventbase
+// Initialize Eventbase
 const eventbase = await createEventbase({
-  dbPath: './data',
-  nats: {
-    servers: ['localhost:4222']
-  },
   streamName: 'myapp',
+  nats: {
+    servers: ['localhost:4222'],
+  },
+  dbPath: './data',
   onMessage: (event) => {
-    console.log('Received', event);
-  }
+    console.log('Event received:', event);
+  },
 });
 
 // Store data
@@ -42,127 +69,270 @@ await eventbase.put('user123', { name: 'John Doe' });
 // Retrieve data with metadata
 const result = await eventbase.get('user123');
 console.log(result);
+// Output:
 // {
 //   data: { name: 'John Doe' },
 //   meta: {
 //     dateCreated: '2023-...',
 //     dateModified: '2023-...',
-//     changes: 1
-//   }
+//     changes: 1,
+//   },
 // }
 
-// Subscribe to changes
-const unsubscribe = eventbase.subscribe('user:*', (key, data, meta, event) => {
-  console.log('Update:', { key, data, meta, event });
+// Subscribe to changes (supports pattern matching)
+const unsubscribe = eventbase.subscribe('user*', (key, data, meta, event) => {
+  console.log('Data changed:', { key, data, meta, event });
 });
 
-// Clean up
+// Clean up when done
 await eventbase.delete('user123');
 unsubscribe();
 await eventbase.close();
 ```
 
-## EventbaseManager
+## Usage
 
-The `createEventbaseManager` method is a wrapper around `Eventbase` that allows for multiple instances to be managed together. It provides a simple API for creating, getting, and deleting instances.
+### Storing Data
 
-```typescript
+```javascript
+await eventbase.put('user123', { name: 'John Doe', email: 'john@example.com' });
+```
+
+- **Key**: A string identifier for your data. Supports special characters.
+- **Data**: Any JSON-serializable object.
+
+### Retrieving Data
+
+```javascript
+const result = await eventbase.get('user123');
+if (result) {
+  const { data, meta } = result;
+  console.log('Data:', data);
+  console.log('Metadata:', meta);
+} else {
+  console.log('Key not found');
+}
+```
+
+- Retrieves data and metadata for a given key.
+- Returns `null` if the key does not exist.
+
+### Deleting Data
+
+```javascript
+await eventbase.delete('user123');
+```
+
+- Removes the data associated with the given key.
+
+### Listing Keys
+
+```javascript
+const keys = await eventbase.keys('user*'); // Supports regex patterns
+console.log('Keys:', keys);
+```
+
+- Retrieves a list of keys matching the provided pattern.
+
+### Subscribing to Changes
+
+```javascript
+const unsubscribe = eventbase.subscribe('user*', (key, data, meta, event) => {
+  console.log('Change detected:', { key, data, meta, event });
+});
+
+// To unsubscribe
+unsubscribe();
+```
+
+- **Filter**: A string pattern to match keys (e.g., `'user*'`, `'user:*:profile'`).
+- **Callback**: A function that is called whenever data matching the filter changes.
+
+### Closing the Connection
+
+```javascript
+await eventbase.close();
+```
+
+- Closes the Eventbase instance and cleans up resources.
+
+## Eventbase Manager
+
+The `createEventbaseManager` function provides an efficient way to manage multiple Eventbase instances. It handles the creation, retrieval, and automatic cleanup of instances based on inactivity.
+
+```javascript
 import { createEventbaseManager } from '@markwylde/eventbase';
 
 const manager = createEventbaseManager({
   dbPath: './data',
   nats: {
-    servers: ['localhost:4222']
+    servers: ['localhost:4222'],
   },
-  keepAliveSeconds: 3600 // Keep each stream alive for 1 hour
+  keepAliveSeconds: 3600, // Keep streams alive for 1 hour of inactivity
 });
 
-const eventbase = await manager.getStream('testStreamName');
+const eventbase = await manager.getStream('streamName');
 
-await eventbase.put('user123', { name: 'John Doe' });
+// Use the eventbase instance
+await eventbase.put('key', { data: 'value' });
+
+// Close all instances when done
+await manager.closeAll();
 ```
 
 ## API
 
-### `createEventbase(config)`
+### Eventbase
+
+#### `createEventbase(config)`
+
 Creates a new Eventbase instance.
 
-#### Config Options:
+##### Config Options:
+
+- **`streamName`**: *(string, required)* Name of the NATS JetStream.
+- **`nats`**: *(ConnectionOptions, required)* NATS connection options.
+- **`dbPath`**: *(string, optional)* Path for persistent storage. Defaults to a temporary directory.
+- **`onMessage`**: *(function, optional)* Callback for every event received.
+
+##### Example:
+
 ```javascript
-{
+const eventbase = await createEventbase({
+  streamName: 'myapp',
   nats: {
-    servers: ['localhost:4222'] // NATS server addresses
+    servers: ['localhost:4222'],
   },
-  streamName: 'myapp' // Name of the NATS stream
-}
-```
-
-### Methods
-
-#### `put(key: string, data: any): Promise<void>`
-Stores data with the given key.
-
-#### `get(key: string): Promise<null | { data: any, meta: Metadata }>`
-Retrieves data and metadata for the given key. Returns null if not found.
-```javascript
-type Metadata = {
-  dateCreated: string;
-  dateModified: string;
-  changes: number;
-}
-```
-
-#### `delete(key: string): Promise<void>`
-Deletes data with the given key.
-
-#### `keys(pattern: string): Promise<string[]>`
-Returns an array of keys matching the given pattern.
-```javascript
-const keys = await eventbase.keys('user:*');
-```
-
-#### `subscribe(pattern: string, callback: Function): Function`
-Subscribes to updates matching the pattern. Returns an unsubscribe function.
-```javascript
-const unsubscribe = eventbase.subscribe('user:*', (key, data, meta, event) => {
-  console.log('Update:', { key, data, meta, event });
+  dbPath: './data',
+  onMessage: (event) => {
+    console.log('Event received:', event);
+  },
 });
 ```
-Callback receives:
-- `key`: The updated key
-- `data`: The current data
-- `meta`: Metadata object
-- `event`: Event details including type and timestamp
 
-#### `close(): Promise<void>`
-Closes the connection and cleans up resources.
+#### Methods
 
-## Features in Detail
+##### `put(key: string, data: object): Promise<{ meta: MetaData; data: T }>`
 
-### Metadata Tracking
-Every stored item includes metadata:
-- `dateCreated`: When the item was first created
-- `dateModified`: When the item was last modified
-- `changes`: Number of updates to the item
+Stores data under the specified key.
 
-### Pattern Matching
-Supports glob-style patterns for both keys() and subscribe():
+##### `get<T>(key: string): Promise<{ meta: MetaData; data: T } | null>`
+
+Retrieves data and metadata for the specified key.
+
+##### `delete(key: string): Promise<{ purged: number }>`
+
+Deletes the data associated with the specified key.
+
+##### `keys(pattern: string): Promise<string[]>`
+
+Returns a list of keys matching the provided pattern (supports regex).
+
+##### `subscribe<T>(filter: string, callback: SubscriptionCallback<T>): () => void`
+
+Subscribes to changes on keys matching the filter. Returns an `unsubscribe` function.
+
+- **`filter`**: String pattern to match keys (e.g., `'user*'`).
+- **`callback`**: Function called with `(key, data, meta, event)` whenever a matching key changes.
+
+##### `close(): Promise<void>`
+
+Closes the Eventbase instance and cleans up resources.
+
+### EventbaseManager
+
+#### `createEventbaseManager(config)`
+
+Creates a new EventbaseManager instance to manage multiple Eventbase instances.
+
+##### Config Options:
+
+- **`dbPath`**: *(string, optional)* Base path for persistent storage.
+- **`nats`**: *(ConnectionOptions, required)* NATS connection options.
+- **`keepAliveSeconds`**: *(number, optional)* Time in seconds to keep inactive streams alive. Default is `3600` (1 hour).
+- **`onMessage`**: *(function, optional)* Global event handler for all streams.
+- **`cleanupIntervalMs`**: *(number, optional)* Interval in milliseconds for cleaning up inactive streams. Default is `60000` (60 seconds).
+
+##### Example:
+
 ```javascript
-'user:*'      // Matches all user keys
-'order:2023:*' // Matches all 2023 orders
+const manager = createEventbaseManager({
+  dbPath: './data',
+  nats: {
+    servers: ['localhost:4222'],
+  },
+  keepAliveSeconds: 3600, // 1 hour
+});
 ```
 
-### Distributed Synchronization
-Multiple instances automatically sync data through NATS JetStream.
+#### Methods
+
+##### `getStream(streamName: string): Promise<EventbaseInstance>`
+
+Gets or creates an Eventbase instance for the given stream name.
+
+##### `closeAll(): Promise<void>`
+
+Closes all managed Eventbase instances and stops the cleanup interval.
+
+## Examples
+
+### Advanced Subscription
+
+Subscribe to changes on keys that match a complex pattern:
+
+```javascript
+// Subscribe to all keys starting with 'user:' and ending with ':profile'
+const unsubscribe = eventbase.subscribe('user:*:profile', (key, data, meta, event) => {
+  console.log('Profile updated:', { key, data });
+});
+
+// To unsubscribe later
+unsubscribe();
+```
+
+### Using with Multiple Streams
+
+Using the EventbaseManager to handle multiple streams:
+
+```javascript
+const manager = createEventbaseManager({
+  nats: {
+    servers: ['localhost:4222'],
+  },
+});
+
+const ordersBase = await manager.getStream('orders');
+const usersBase = await manager.getStream('users');
+
+// Work with the 'orders' stream
+await ordersBase.put('order123', { item: 'Laptop', quantity: 1 });
+
+// Work with the 'users' stream
+await usersBase.put('user123', { name: 'Alice' });
+
+// Close all streams when done
+await manager.closeAll();
+```
 
 ## Development
+
+Clone the repository and install dependencies:
+
 ```bash
-# Start NATS
-docker compose up -d
-
-# Install dependencies
+git clone https://github.com/markwylde/eventbase.git
+cd eventbase
 npm install
+```
 
-# Run tests
+Start NATS server using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+Run tests:
+
+```bash
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ import createEventbase from '@markwylde/eventbase';
 
 // Initialize eventbase
 const eventbase = await createEventbase({
+  dbPath: './data',
   nats: {
     servers: ['localhost:4222']
   },
@@ -59,6 +60,26 @@ const unsubscribe = eventbase.subscribe('user:*', (key, data, meta, event) => {
 await eventbase.delete('user123');
 unsubscribe();
 await eventbase.close();
+```
+
+## EventbaseManager
+
+The `createEventbaseManager` method is a wrapper around `Eventbase` that allows for multiple instances to be managed together. It provides a simple API for creating, getting, and deleting instances.
+
+```typescript
+import { createEventbaseManager } from '@markwylde/eventbase';
+
+const manager = createEventbaseManager({
+  dbPath: './data',
+  nats: {
+    servers: ['localhost:4222']
+  },
+  keepAliveSeconds: 3600 // Keep each stream alive for 1 hour
+});
+
+const eventbase = await manager.getStream('testStreamName');
+
+await eventbase.put('user123', { name: 'John Doe' });
 ```
 
 ## API

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,20 +1,18 @@
 import { Level } from 'level';
 import { join } from 'path';
-import { rm } from 'fs/promises';
+import { mkdir } from 'fs/promises';
 import { tmpdir } from 'os';
 
-export async function createDb(streamName: string) {
-  const dbPath = join(tmpdir(), `level-${streamName}-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`);
+export async function createDb(streamName: string, dbPath?: string) {
+  const path = dbPath
+    ? join(dbPath, `level-${streamName}`)
+    : join(tmpdir(), `level-${streamName}`);
 
-  // Delete existing DB (just in case)
-  try {
-    await rm(dbPath, { recursive: true, force: true });
-  } catch (err) {
-    // Ignore if doesn't exist
-  }
+  // Ensure the directory exists
+  await mkdir(dbPath || tmpdir(), { recursive: true });
 
-  // Create fresh DB
-  const db = new Level<string, object>(dbPath, { valueEncoding: 'json' });
+  // Open existing DB or create a new one
+  const db = new Level<string, object>(path, { valueEncoding: 'json' });
   await db.open();
 
   return db;

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,0 +1,100 @@
+import { createEventbase } from './index.js';
+import type { EventbaseConfig } from './types.js';
+
+type EventbaseInstance = Awaited<ReturnType<typeof createEventbase>>;
+
+type EventbaseInstances = {
+  [streamName: string]: {
+    instance: EventbaseInstance;
+    lastAccessed: number;
+  };
+};
+
+export type EventbaseManagerConfig = {
+  dbPath?: string;
+  nats: EventbaseConfig['nats'];
+  keepAliveSeconds?: number;
+  onMessage?: EventbaseConfig['onMessage'];
+  cleanupIntervalMs?: number;
+};
+
+export function createEventbaseManager(config: EventbaseManagerConfig) {
+  const instances: EventbaseInstances = {};
+  const {
+    dbPath,
+    nats,
+    keepAliveSeconds = 3600, // Default to 1 hour
+    onMessage,
+    cleanupIntervalMs = 60000, // Default to 60 seconds
+  } = config;
+
+  let cleanupInterval: NodeJS.Timeout | null = null;
+
+  const startCleanupInterval = () => {
+    if (cleanupInterval) return;
+
+    cleanupInterval = setInterval(async () => {
+      const now = Date.now();
+      const staleInstances = Object.entries(instances).filter(
+        ([_, { lastAccessed }]) => now - lastAccessed > keepAliveSeconds * 1000
+      );
+
+      for (const [streamName, { instance }] of staleInstances) {
+        try {
+          await instance.close();
+          delete instances[streamName];
+        } catch (error) {
+          console.error(`Error closing stale instance ${streamName}:`, error);
+        }
+      }
+    }, cleanupIntervalMs);
+  };
+
+  const stopCleanupInterval = () => {
+    if (cleanupInterval) {
+      clearInterval(cleanupInterval);
+      cleanupInterval = null;
+    }
+  };
+
+  return {
+    getStream: async (streamName: string) => {
+      if (!instances[streamName]) {
+        const instance = await createEventbase({
+          streamName,
+          nats,
+          dbPath: dbPath ? `${dbPath}/${streamName}` : undefined,
+          onMessage,
+        });
+
+        instances[streamName] = {
+          instance,
+          lastAccessed: Date.now(),
+        };
+
+        startCleanupInterval();
+      } else {
+        instances[streamName].lastAccessed = Date.now();
+      }
+
+      return instances[streamName].instance;
+    },
+
+    closeAll: async () => {
+      stopCleanupInterval();
+
+      const closePromises = Object.entries(instances).map(async ([streamName, { instance }]) => {
+        try {
+          await instance.close();
+        } catch (error) {
+          console.error(`Error closing instance ${streamName}:`, error);
+        }
+      });
+
+      await Promise.all(closePromises);
+
+      // Clear all instances
+      Object.keys(instances).forEach(key => delete instances[key]);
+    }
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { ConnectionOptions } from "@nats-io/transport-node";
 export type EventbaseConfig = {
   streamName: string;
   nats: ConnectionOptions;
+  dbPath?: string;
   onMessage?: (event: Omit<Event, 'oldData'>) => void;
 };
 
@@ -12,4 +13,9 @@ export type Event = {
   data?: any;
   oldData?: any;
   timestamp: number;
+};
+
+export type Stream = {
+  waitUntilReady: () => Promise<void>;
+  stop: () => Promise<void>;
 };

--- a/test/manager.test.ts
+++ b/test/manager.test.ts
@@ -1,0 +1,125 @@
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createEventbaseManager } from '../src/manager.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('EventbaseManager', () => {
+  let manager;
+  let dbPath;
+
+  beforeEach(() => {
+    dbPath = mkdtempSync(join(tmpdir(), 'eventbase-test-'));
+    manager = createEventbaseManager({
+      dbPath,
+      nats: {
+        servers: ['localhost:4222'],
+        user: 'a',
+        pass: 'a',
+      },
+      keepAliveSeconds: 60,
+      cleanupIntervalMs: 60000,
+    });
+  });
+
+  afterEach(async () => {
+    await manager.closeAll();
+    rmSync(dbPath, { recursive: true, force: true });
+  });
+
+  test('should create and retrieve streams', async () => {
+    const streamName = `testStream-${Date.now()}`;
+    const eventbase1 = await manager.getStream(streamName);
+    assert.ok(eventbase1);
+
+    const eventbase2 = await manager.getStream(streamName);
+    assert.strictEqual(eventbase1, eventbase2);
+  });
+
+  test('should manage multiple streams independently', async () => {
+    const streamName1 = `stream1-${Date.now()}`;
+    const streamName2 = `stream2-${Date.now()}`;
+    const eventbase1 = await manager.getStream(streamName1);
+    const eventbase2 = await manager.getStream(streamName2);
+
+    assert.notStrictEqual(eventbase1, eventbase2);
+
+    await eventbase1.put('key1', { data: 'value1' });
+    const result1 = await eventbase1.get('key1');
+    assert.deepEqual(result1.data, { data: 'value1' });
+
+    const result2 = await eventbase2.get('key1');
+    assert.strictEqual(result2, null);
+  });
+
+  test('should automatically close streams after keepAliveSeconds', async () => {
+    const shortManager = createEventbaseManager({
+      dbPath,
+      nats: {
+        servers: ['localhost:4222'],
+        user: 'a',
+        pass: 'a',
+      },
+      keepAliveSeconds: 1,
+      cleanupIntervalMs: 500,
+    });
+
+    try {
+      const streamName = `autoCloseStream-${Date.now()}`;
+      const eventbase = await shortManager.getStream(streamName);
+      await eventbase.put('key', { data: 'value' });
+
+      // Wait for longer than keepAliveSeconds
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      const newEventbase = await shortManager.getStream(streamName);
+      assert.notStrictEqual(eventbase, newEventbase);
+
+      const result = await newEventbase.get('key');
+      assert.deepEqual(result.data, { data: 'value' });
+    } finally {
+      await shortManager.closeAll();
+    }
+  });
+
+  test('should close all instances when closeAll is called', async () => {
+    const streamName = `streamToClose-${Date.now()}`;
+    const eventbase = await manager.getStream(streamName);
+    assert.ok(eventbase);
+
+    await manager.closeAll();
+
+    const newEventbase = await manager.getStream(streamName);
+    assert.notStrictEqual(eventbase, newEventbase);
+  });
+
+  test('should pass onMessage to Eventbase instances', async () => {
+    let messageReceived = false;
+    const messageManager = createEventbaseManager({
+      dbPath,
+      nats: {
+        servers: ['localhost:4222'],
+        user: 'a',
+        pass: 'a'
+      },
+      onMessage: (event) => {
+        messageReceived = true;
+        assert.ok(event);
+      },
+      keepAliveSeconds: 60,
+      cleanupIntervalMs: 60000,
+    });
+
+    try {
+      const streamName = `onMessageStream-${Date.now()}`;
+      const eventbase = await messageManager.getStream(streamName);
+      await eventbase.put('key', { data: 'value' });
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+      assert.ok(messageReceived);
+    } finally {
+      await messageManager.closeAll();
+    }
+  });
+});


### PR DESCRIPTION
The `createEventbaseManager` method is a wrapper around `Eventbase` that allows for multiple instances to be managed together. It provides a simple API for creating, getting, and deleting instances.

```typescript
import { createEventbaseManager } from '@markwylde/eventbase';

const manager = createEventbaseManager({
  dbPath: './data',
  nats: {
    servers: ['localhost:4222']
  },
  keepAliveSeconds: 3600 // Keep each stream alive for 1 hour
});

const eventbase = await manager.getStream('testStreamName');

await eventbase.put('user123', { name: 'John Doe' });
```