### PR TITLE
feat: implement query and queryResultCount on stats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,8 @@ export async function createEventbase(config: EventbaseConfig) {
       const result = await db.query(queryObject as any, options as any);
       await publishStats({
         operation: 'QUERY',
+        query: queryObject,
+        queryResultCount: result.length,
         timestamp: start,
         duration: Date.now() - start
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export type StatsEvent = {
   operation: 'GET' | 'QUERY' |  'PUT' | 'DELETE' | 'KEYS' | 'SUBSCRIBE' | 'SUBSCRIBE_EMIT';
   id?: string;
   pattern?: string;
+  query?: object;
+  queryResultCount?: number;
   timestamp: number;
   duration: number;
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -151,7 +151,33 @@ describe('Eventbase with Stats', async () => {
     subscription();
   });
 
-  // Your original tests can continue from here
+  test('should publish stats events for query operation with query details', async () => {
+    // Setup some test data
+    await eventbase1.put('person1', { firstName: 'Joe', lastName: 'Smith' });
+    await eventbase1.put('person2', { firstName: 'Joe', lastName: 'Brown' });
+    await eventbase1.put('person3', { firstName: 'Jane', lastName: 'Doe' });
+
+    // Clear previous stats events
+    statsEvents = [];
+
+    // Perform the query
+    const queryObject = { firstName: { $eq: 'Joe' } };
+    const result = await eventbase1.query(queryObject);
+
+    // Wait for stats event to be published
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify stats event
+    assert.equal(statsEvents.length, 1);
+    const statsEvent = statsEvents[0];
+
+    assert.equal(statsEvent.operation, 'QUERY');
+    assert.deepEqual(statsEvent.query, queryObject);
+    assert.equal(statsEvent.queryResultCount, 2);
+    assert.ok(typeof statsEvent.timestamp === 'number');
+    assert.ok(typeof statsEvent.duration === 'number');
+  });
+
   test('should store and retrieve data with metadata', async () => {
     const testData = { name: 'John Doe', age: 30 };
     await eventbase1.put('user1', testData);


### PR DESCRIPTION
This enhancement provides more detailed insights into query operations, making it easier to:
- Debug complex queries
- Monitor query performance
- Analyze query patterns and results

This is a backward-compatible enhancement to the existing statistics system.

# Changes
- Added additional metadata to query operation statistics events
- Now tracking the actual query object used and the number of results returned
- Added comprehensive test coverage for the new statistics fields

## Details
The PR enhances the statistics tracking for query operations by including:
- The actual query object used (`query` field)
- The number of results returned (`queryResultCount` field)

## Types
Updated `StatsEvent` type to include new optional fields:
- `query?: object`
- `queryResultCount?: number`
